### PR TITLE
Remove HTTPS enforcement for local environments in AppServiceProvider.php

### DIFF
--- a/stubs/AppServiceProvider.php
+++ b/stubs/AppServiceProvider.php
@@ -17,7 +17,9 @@ class AppServiceProvider extends ServiceProvider
 
         Number::useLocale('en');
         URL::defaults(['domain' => '']);
-        URL::forceScheme('https');
+        if (!$this->app->isLocal()) {
+            URL::forceScheme('https');
+        }
         Model::unguard();
     }
 }


### PR DESCRIPTION
Adjusted conditional logic to enforce HTTPS scheme only for non-local environments.